### PR TITLE
fix: st pull failing sanity check in empty folder

### DIFF
--- a/src/commander.ts
+++ b/src/commander.ts
@@ -52,7 +52,7 @@ export async function runCLI(argv: string[]) {
     .option("--verbose", "set log level to debug")
     .option("-f --force", "skip checking state, pull all files")
     .action(async (projectPath = ".", options) => {
-      await withSafeEnvironment({ projectPath, options }, async () => {
+      await withSafeEnvironment({ projectPath, options, skipSanityCheck: true }, async () => {
         await pullSearchTemplate({
           paths: options.paths ?? [],
           force: options.force ?? false

--- a/src/modules/search-templates/pull.ts
+++ b/src/modules/search-templates/pull.ts
@@ -83,6 +83,7 @@ export async function pullSearchTemplate({ paths, force }: PullSearchTemplateOpt
 
   // Write the hash
   if (!dryRun && fs.existsSync(path.join(targetFolder, "build/hash"))) {
+    fs.mkdirSync(path.join(targetFolder, ".nostocache"), { recursive: true })
     fs.copyFileSync(path.join(targetFolder, "build/hash"), path.join(targetFolder, ".nostocache/hash"))
   }
 }

--- a/src/utils/withSafeEnvironment.ts
+++ b/src/utils/withSafeEnvironment.ts
@@ -3,10 +3,19 @@ import { withErrorHandler } from "#errors/withErrorHandler.ts"
 import { assertGitRepo } from "#filesystem/asserts/assertGitRepo.ts"
 import { assertNostoTemplate } from "#filesystem/asserts/assertNostoTemplate.ts"
 
-export async function withSafeEnvironment(props: LoadConfigProps, fn: () => void | Promise<void>): Promise<void> {
+type Props = LoadConfigProps & {
+  skipSanityCheck?: boolean
+}
+
+export async function withSafeEnvironment(
+  { skipSanityCheck, ...props }: Props,
+  fn: () => void | Promise<void>
+): Promise<void> {
   await withErrorHandler(async () => {
     loadConfig(props)
-    assertNostoTemplate()
+    if (!skipSanityCheck) {
+      assertNostoTemplate()
+    }
     assertGitRepo()
     await fn()
   })

--- a/test/commander.test.ts
+++ b/test/commander.test.ts
@@ -106,7 +106,7 @@ describe("commander", () => {
     })
   })
 
-  describe("nosto st build", () => {
+  describe("nosto search-templates build", () => {
     it("should fail sanity check", async () => {
       await commander.run("nosto st build")
       expect(buildSpy).not.toHaveBeenCalled()
@@ -143,9 +143,9 @@ describe("commander", () => {
   })
 
   describe("nosto search-templates pull", () => {
-    it("should fail sanity check", async () => {
+    it("should pull even without files present", async () => {
       await commander.run("nosto st pull")
-      expect(pullSpy).not.toHaveBeenCalled()
+      expect(pullSpy).toHaveBeenCalled()
     })
 
     describe("with valid environment", () => {


### PR DESCRIPTION
## Context

<!-- One or two descriptive sentences about context and reason behind the PR is enough. -->
Tiny bugfix for the case where one attempts to pull in an empty folder without index.js present. It would fail the sanity check and decline pulling.

## Related Jira ticket

<!-- If applicable, share the link to and update the status of the ticket. -->

## Screenshots

<!-- If there is a visual element to the PR please share screenshots -->
<!-- Remember the saying "one picture says the same as a 1000 words". -->
