### PR TITLE
fix: fetch library before dev mode

### DIFF
--- a/src/modules/search-templates/dev.ts
+++ b/src/modules/search-templates/dev.ts
@@ -1,10 +1,19 @@
 import chalk from "chalk"
+import path from "path"
 
+import { getCachedConfig } from "#config/config.ts"
 import { Logger } from "#console/logger.ts"
 import { getBuildContext } from "#filesystem/esbuild.ts"
+import { loadLibrary } from "#filesystem/loadLibrary.ts"
 import { pushOnRebuildPlugin } from "#filesystem/plugins.ts"
 
 export async function searchTemplateDevMode() {
+  const { projectPath } = getCachedConfig()
+  const libraryPath = path.resolve(projectPath, ".nostocache/library")
+
+  Logger.info(`Fetching library to: ${chalk.cyan(libraryPath)}`)
+  await loadLibrary(libraryPath)
+
   Logger.info(`Watching for changes. ${chalk.yellow("Press Ctrl+C to stop")}`)
 
   const context = await getBuildContext({ plugins: [pushOnRebuildPlugin()] })


### PR DESCRIPTION
## Context

<!-- One or two descriptive sentences about context and reason behind the PR is enough. -->
Before this fix, dev mode required `nosto st build` or `nosto st push` to have run once before to pull the library. Now it's pulled automatically.

## Related Jira ticket

<!-- If applicable, share the link to and update the status of the ticket. -->

## Screenshots

<!-- If there is a visual element to the PR please share screenshots -->
<!-- Remember the saying "one picture says the same as a 1000 words". -->
