### PR TITLE
fix: never ignore build folder

### DIFF
--- a/test/modules/search-templates/push.test.ts
+++ b/test/modules/search-templates/push.test.ts
@@ -56,6 +56,20 @@ describe("Push Search Template", () => {
     expect(terminal.getSpy("info")).toHaveBeenCalledWith("Found 4 files to push (3 source, 1 built, 1 ignored).")
   })
 
+  it("should not ignore build directory", async () => {
+    fs.writeFile(".gitignore", "build/")
+    fs.writeFile("index.js", "content with @nosto/preact")
+    fs.writeFile("build/index.js", "build content")
+
+    mockPutSourceFile(server, { path: "index.js" })
+    mockPutSourceFile(server, { path: "build/index.js" })
+
+    await pushSearchTemplate({ paths: [], force: true })
+
+    expect(terminal.getSpy("info")).toHaveBeenCalledWith("Pushing template from: /")
+    expect(terminal.getSpy("info")).toHaveBeenCalledWith("Found 3 files to push (1 source, 2 built, 0 ignored).")
+  })
+
   it("should cancel operation when user declines", async () => {
     fs.writeFile("index.js", "content with @nosto/preact")
     fs.writeFile("file1.js", "file1 content")


### PR DESCRIPTION
## Context

<!-- One or two descriptive sentences about context and reason behind the PR is enough. -->
Broken some commits ago. Build folder would be excluded from push if it's in .gitignore file. Now it's always included.

## Related Jira ticket

<!-- If applicable, share the link to and update the status of the ticket. -->

## Screenshots

<!-- If there is a visual element to the PR please share screenshots -->
<!-- Remember the saying "one picture says the same as a 1000 words". -->
