### PR TITLE
Remove npm audit workflow steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,6 @@ jobs:
     - name: Install dependencies
       run: npm ci
 
-    - name: Audit dependencies
-      run: npm audit --audit-level=high
-
     - name: Run linting
       run: npm run lint
 
@@ -38,9 +35,6 @@ jobs:
     - name: Install dependencies
       run: npm ci
 
-    - name: Audit dependencies
-      run: npm audit --audit-level=high
-
     - name: Run TypeScript type checking
       run: npm run type-check
 
@@ -57,9 +51,6 @@ jobs:
 
     - name: Install dependencies
       run: npm ci
-
-    - name: Audit dependencies
-      run: npm audit --audit-level=high
 
     - name: Run tests
       run: npm run test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,9 +31,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Audit dependencies
-        run: npm audit --audit-level=high
-
       - name: Run tests
         run: npm test
 


### PR DESCRIPTION
## Summary
- remove npm audit steps from CI lint, type-check, and test jobs
- remove npm audit step from the release workflow

## Testing
- not run; workflow YAML-only cleanup