### PR TITLE
feat: avoid pushing sources without explicit opt in

### DIFF
--- a/src/commander.ts
+++ b/src/commander.ts
@@ -141,12 +141,14 @@ export async function runCLI(argv: string[]) {
     .option("--dry-run", "perform a dry run without making changes")
     .option("--verbose", "set log level to debug")
     .option("-f --force", "skip checking state, push all files")
+    .option("--push-sources", "for modern templates, also push the sources to S3")
     .action(async (projectPath = ".", options) => {
       await withSafeEnvironment({ projectPath, options }, async () => {
         await buildSearchTemplate({ watch: false })
         await pushSearchTemplate({
-          paths: options.paths ?? [],
-          force: options.force ?? false
+          paths: options.paths,
+          force: options.force ?? false,
+          pushSources: options.pushSources ?? false
         })
       })
     })

--- a/src/modules/search-templates/push.ts
+++ b/src/modules/search-templates/push.ts
@@ -14,7 +14,7 @@ import { processInBatches } from "#filesystem/processInBatches.ts"
 
 type PushSearchTemplateOptions = {
   // Filter to only push these files. Ignored if empty.
-  paths: string[]
+  paths?: string[]
   // Skip checking the hash and push all files.
   force?: boolean
   // For modern templates, also push the sources to S3.
@@ -37,7 +37,7 @@ export async function pushSearchTemplate({
   }
 }
 
-async function performPushSearchTemplate({ paths, force }: Omit<PushSearchTemplateOptions, "sources">) {
+async function performPushSearchTemplate({ paths, force }: { paths: string[]; force?: boolean }) {
   const { projectPath } = getCachedConfig()
   const targetFolder = path.resolve(projectPath)
 

--- a/src/modules/search-templates/push.ts
+++ b/src/modules/search-templates/push.ts
@@ -9,20 +9,35 @@ import { Logger } from "#console/logger.ts"
 import { promptForConfirmation } from "#console/userPrompt.ts"
 import { calculateTreeHash } from "#filesystem/calculateTreeHash.ts"
 import { listAllFiles, readFileIfExists, writeFile } from "#filesystem/filesystem.ts"
+import { isModernTemplateProject } from "#filesystem/legacyUtils.ts"
 import { processInBatches } from "#filesystem/processInBatches.ts"
 
 type PushSearchTemplateOptions = {
   // Filter to only push these files. Ignored if empty.
   paths: string[]
   // Skip checking the hash and push all files.
-  force: boolean
+  force?: boolean
+  // For modern templates, also push the sources to S3.
+  pushSources?: boolean
 }
 
 /**
  * Deploys templates to the specified target path.
  * Processes files in parallel with controlled concurrency and retry logic.
  */
-export async function pushSearchTemplate({ paths, force }: PushSearchTemplateOptions) {
+export async function pushSearchTemplate({
+  paths,
+  pushSources,
+  ...options
+}: Omit<PushSearchTemplateOptions, "paths"> & { paths?: string[] }) {
+  if (isModernTemplateProject() && !pushSources) {
+    await performPushSearchTemplate({ paths: paths ?? ["build"], ...options })
+  } else {
+    await performPushSearchTemplate({ paths: paths ?? [], ...options })
+  }
+}
+
+async function performPushSearchTemplate({ paths, force }: Omit<PushSearchTemplateOptions, "sources">) {
   const { projectPath } = getCachedConfig()
   const targetFolder = path.resolve(projectPath)
 

--- a/test/commander.test.ts
+++ b/test/commander.test.ts
@@ -385,19 +385,19 @@ describe("commander", () => {
       it("should call the build and push functions", async () => {
         await commander.run("nosto st push")
         expect(buildSpy).toHaveBeenCalledWith({ watch: false })
-        expect(pushSpy).toHaveBeenCalledWith({ force: false, paths: [] })
+        expect(pushSpy).toHaveBeenCalledWith({ force: false, pushSources: false })
       })
 
       it("should call the function with short parameters", async () => {
         await commander.run("nosto st push -f -p build index.js")
         expect(buildSpy).toHaveBeenCalledWith({ watch: false })
-        expect(pushSpy).toHaveBeenCalledWith({ force: true, paths: ["build", "index.js"] })
+        expect(pushSpy).toHaveBeenCalledWith({ force: true, paths: ["build", "index.js"], pushSources: false })
       })
 
       it("should call the function with full parameters", async () => {
-        await commander.run("nosto st push --force --paths build index.js")
+        await commander.run("nosto st push --force --push-sources --paths build index.js")
         expect(buildSpy).toHaveBeenCalledWith({ watch: false })
-        expect(pushSpy).toHaveBeenCalledWith({ force: true, paths: ["build", "index.js"] })
+        expect(pushSpy).toHaveBeenCalledWith({ force: true, paths: ["build", "index.js"], pushSources: true })
       })
 
       it("should rethrow errors", async () => {

--- a/test/modules/search-templates/push.modern.test.ts
+++ b/test/modules/search-templates/push.modern.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { pushSearchTemplate } from "#modules/search-templates/push.ts"
+import { setupMockConsole } from "#test/utils/mockConsole.ts"
+import { setupMockFileSystem } from "#test/utils/mockFileSystem.ts"
+import { mockPutSourceFile, setupMockServer } from "#test/utils/mockServer.ts"
+import { setupMockStarterManifest } from "#test/utils/mockStarterManifest.ts"
+
+const fs = setupMockFileSystem()
+const server = setupMockServer()
+const terminal = setupMockConsole()
+
+describe("Push Search Templates / Modern", () => {
+  it("should only push built artifacts if paths are not provided", async () => {
+    setupMockStarterManifest({ mockScript: { onBuild: vi.fn() } })
+    fs.writeFile("index.js", "source content")
+    fs.writeFile("build/hash", "some-hash")
+    fs.writeFile("build/index.js", "built content")
+
+    mockPutSourceFile(server, { path: "build/index.js" })
+
+    terminal.setUserResponse("y")
+
+    await pushSearchTemplate({})
+
+    expect(terminal.getSpy("info")).toHaveBeenCalledWith("Found 2 files to push (0 source, 2 built, 2 ignored).")
+  })
+
+  it("should respect paths regardless of pushSources", async () => {
+    setupMockStarterManifest({ mockScript: { onBuild: vi.fn() } })
+    fs.writeFile("source.js", "source content")
+    fs.writeFile("build/hash", "some-hash")
+    fs.writeFile("build/index.js", "built content")
+
+    mockPutSourceFile(server, { path: "source.js" })
+
+    terminal.setUserResponse("y")
+
+    await pushSearchTemplate({ paths: ["source.js"] })
+
+    expect(terminal.getSpy("info")).toHaveBeenCalledWith("Found 2 files to push (1 source, 1 built, 2 ignored).")
+  })
+
+  it("should push sources by default if pushSources is true", async () => {
+    setupMockStarterManifest({ mockScript: { onBuild: vi.fn() } })
+    fs.writeFile("index.js", "source content")
+    fs.writeFile("build/hash", "some-hash")
+    fs.writeFile("build/index.js", "built content")
+
+    mockPutSourceFile(server, { path: "index.js" })
+    mockPutSourceFile(server, { path: "build/index.js" })
+    mockPutSourceFile(server, { path: "nosto.config.ts" })
+
+    terminal.setUserResponse("y")
+
+    await pushSearchTemplate({ pushSources: true })
+
+    expect(terminal.getSpy("info")).toHaveBeenCalledWith("Found 4 files to push (2 source, 2 built, 0 ignored).")
+  })
+})


### PR DESCRIPTION
## Context

<!-- One or two descriptive sentences about context and reason behind the PR is enough. -->
With modern templates, in most cases users don't want to push the sources over to S3. This is now the default behaviour for `nosto st push`, as it will only push the built artifacts.

## Related Jira ticket

<!-- If applicable, share the link to and update the status of the ticket. -->
https://nostosolutions.atlassian.net/browse/SEARCH-2277

## Screenshots

<!-- If there is a visual element to the PR please share screenshots -->
<!-- Remember the saying "one picture says the same as a 1000 words". -->
