### PR TITLE
fix: ky swallowing error body

### DIFF
--- a/src/errors/withErrorHandler.ts
+++ b/src/errors/withErrorHandler.ts
@@ -7,14 +7,6 @@ import { Logger } from "#console/logger.ts"
 import { NostoError } from "./NostoError.ts"
 
 export async function withErrorHandler(fn: () => void | Promise<void>): Promise<void> {
-  function printStack(error: Error) {
-    const config = getCachedConfig()
-    if (config.verbose) {
-      Logger.raw(chalk.red(prettyPrintStack(error.stack)))
-    } else {
-      Logger.info(chalk.gray("Rerun with --verbose to see details"))
-    }
-  }
   try {
     await fn()
   } catch (error) {
@@ -22,7 +14,7 @@ export async function withErrorHandler(fn: () => void | Promise<void>): Promise<
       Logger.error(`HTTP Request failed:`)
       Logger.error(`- ${error.response.status} ${error.response.statusText}`)
       Logger.error(`- ${error.request.method} ${error.request.url}`)
-      Logger.error(`- ${await error.response.text()}`)
+      Logger.error(`- ${typeof error.data === "string" ? error.data : JSON.stringify(error.data)}`)
       printStack(error)
     } else if (error instanceof TimeoutError) {
       Logger.error(`HTTP Request timed out:`)
@@ -34,6 +26,15 @@ export async function withErrorHandler(fn: () => void | Promise<void>): Promise<
     } else {
       throw error
     }
+  }
+}
+
+function printStack(error: Error) {
+  const config = getCachedConfig()
+  if (config.verbose) {
+    Logger.raw(chalk.red(prettyPrintStack(error.stack)))
+  } else {
+    Logger.info(chalk.gray("Rerun with --verbose to see details"))
   }
 }
 

--- a/test/errors/withErrorHandler.test.ts
+++ b/test/errors/withErrorHandler.test.ts
@@ -67,11 +67,10 @@ describe("Error Handler", () => {
 
   it("should handle HTTPError", async () => {
     const mockFn = vi.fn(() => {
-      throw new HTTPError(
+      const error = new HTTPError(
         {
           status: 500,
-          statusText: "Internal Server Error",
-          text: () => Promise.resolve("Internal Server Error body")
+          statusText: "Internal Server Error"
         } as unknown as Response,
         {
           method: "GET",
@@ -79,6 +78,8 @@ describe("Error Handler", () => {
         } as Request,
         {} as never
       )
+      error.data = "Internal Server Error body"
+      throw error
     })
 
     await expect(withErrorHandler(mockFn)).resolves.toBeUndefined()


### PR DESCRIPTION
## Context

<!-- One or two descriptive sentences about context and reason behind the PR is enough. -->
Some time earlier, `ky` (the HTTP library, wrapper around fetch) was updated to version 2.0 that included an internal change to how http error body is consumed. In essence, the error was now swallowed.

In reality, the functionality to check merchant ID and return an explicit error message was already present, it just stopped working due to this version bump. It was not caught by tests as the http layer is mocked, so the mock returned the old shape.

## Related Jira ticket

<!-- If applicable, share the link to and update the status of the ticket. -->
https://nostosolutions.atlassian.net/browse/SEARCH-2283

## Screenshots

<!-- If there is a visual element to the PR please share screenshots -->
<!-- Remember the saying "one picture says the same as a 1000 words". -->
<img width="845" height="121" alt="image" src="https://github.com/user-attachments/assets/15fd898a-7e98-4be9-8625-9a31600f22a3" />
