### PR TITLE
fix: better handling of expired login token

### DIFF
--- a/src/commander.ts
+++ b/src/commander.ts
@@ -26,6 +26,7 @@ export async function runCLI(argv: string[]) {
     .description("Login with your Nosto account")
     .option("--verbose", "set log level to debug")
     .action(async options => {
+      removeLoginCredentials()
       await loadConfig({ options, allowIncomplete: true, projectPath: "." })
       await withErrorHandler(async () => {
         await loginToPlaycart()

--- a/src/config/authConfig.ts
+++ b/src/config/authConfig.ts
@@ -29,7 +29,11 @@ export function parseAuthFile({ allowIncomplete }: { allowIncomplete?: boolean }
   try {
     const configContent = fs.readFileSync(AuthConfigFilePath, "utf-8")
     const rawConfig = JSON.parse(configContent)
-    return AuthConfigSchema.parse(rawConfig)
+    const config = AuthConfigSchema.parse(rawConfig)
+    if (config.expiresAt < new Date()) {
+      throw new MissingConfigurationError("Auth token expired. Please run 'nosto login' again to refresh.")
+    }
+    return config
   } catch (error) {
     if (error instanceof z.ZodError) {
       throw new Error(`Invalid auth file at ${AuthConfigFilePath}: ${error.message}`, { cause: error })

--- a/src/config/authConfig.ts
+++ b/src/config/authConfig.ts
@@ -30,7 +30,7 @@ export function parseAuthFile({ allowIncomplete }: { allowIncomplete?: boolean }
     const configContent = fs.readFileSync(AuthConfigFilePath, "utf-8")
     const rawConfig = JSON.parse(configContent)
     const config = AuthConfigSchema.parse(rawConfig)
-    if (config.expiresAt < new Date()) {
+    if (config.expiresAt < new Date() && !allowIncomplete) {
       throw new MissingConfigurationError("Auth token expired. Please run 'nosto login' again to refresh.")
     }
     return config

--- a/test/commander.test.ts
+++ b/test/commander.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, MockInstance, vi } from "vitest"
 
+import { AuthConfigFilePath } from "#config/authConfig.ts"
 import { clearCachedConfig, getCachedConfig } from "#config/config.ts"
 import { MissingConfigurationError } from "#errors/MissingConfigurationError.ts"
 import * as deployModule from "#modules/deployments/deploy.ts"
@@ -61,6 +62,23 @@ describe("commander", () => {
     it("should load the config", async () => {
       await commander.run("nosto login --verbose")
       expect(getCachedConfig().verbose).toBe(true)
+    })
+
+    it("should not throw on expired auth token", async () => {
+      vi.spyOn(logout, "removeLoginCredentials").mockRestore()
+      fs.writeFile(
+        AuthConfigFilePath,
+        JSON.stringify({ user: "test-user", token: "test-token", expiresAt: new Date(0) })
+      )
+      await commander.run("nosto login")
+      expect(loginSpy).toHaveBeenCalledWith()
+    })
+
+    it("should not throw on malformed auth file", async () => {
+      vi.spyOn(logout, "removeLoginCredentials").mockRestore()
+      fs.writeFile(AuthConfigFilePath, "not-a-json")
+      await commander.run("nosto login")
+      expect(loginSpy).toHaveBeenCalledWith()
     })
   })
 

--- a/test/commander.test.ts
+++ b/test/commander.test.ts
@@ -137,6 +137,16 @@ describe("commander", () => {
       expect(statusSpy).toHaveBeenCalledWith("/path/to/project")
     })
 
+    it("should not throw on expired auth token", async () => {
+      vi.spyOn(logout, "removeLoginCredentials").mockRestore()
+      fs.writeFile(
+        AuthConfigFilePath,
+        JSON.stringify({ user: "test-user", token: "test-token", expiresAt: new Date(0) })
+      )
+      await commander.run("nosto status")
+      expect(statusSpy).toHaveBeenCalledWith(".")
+    })
+
     it("should handle MissingConfigurationError", async () => {
       vi.spyOn(status, "printStatus").mockImplementation(() => {
         throw new MissingConfigurationError("Missing configuration")

--- a/test/config/authConfig.test.ts
+++ b/test/config/authConfig.test.ts
@@ -47,6 +47,18 @@ describe("Auth Config", () => {
     expect(() => parseAuthFile({})).toThrowError(/Invalid auth file/)
   })
 
+  it("should throw an error for expired auth token", () => {
+    const config = {
+      user: "testuser@nosto.com",
+      token: "testtoken",
+      expiresAt: new Date(Date.now() - 1000 * 60 * 60)
+    } satisfies AuthConfig
+
+    fs.writeFile(fs.paths.authFile, config)
+
+    expect(() => parseAuthFile({})).toThrowError(/Auth token expired/)
+  })
+
   it("should throw an error for a malformed file", () => {
     fs.writeFile(fs.paths.authFile, "\xff\xfe\xff\xfe")
 

--- a/test/modules/login.test.ts
+++ b/test/modules/login.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from "vitest"
 import { AuthConfigFilePath } from "#config/authConfig.ts"
 import { loginToPlaycart } from "#modules/login.ts"
 import { setupMockAuthServer } from "#test/utils/mockAuthServer.ts"
-import { setupMockConfig } from "#test/utils/mockConfig.ts"
 import { setupMockFileSystem } from "#test/utils/mockFileSystem.ts"
 
 const fs = setupMockFileSystem()

--- a/test/modules/login.test.ts
+++ b/test/modules/login.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest"
 import { AuthConfigFilePath } from "#config/authConfig.ts"
 import { loginToPlaycart } from "#modules/login.ts"
 import { setupMockAuthServer } from "#test/utils/mockAuthServer.ts"
+import { setupMockConfig } from "#test/utils/mockConfig.ts"
 import { setupMockFileSystem } from "#test/utils/mockFileSystem.ts"
 
 const fs = setupMockFileSystem()


### PR DESCRIPTION
## Context

<!-- One or two descriptive sentences about context and reason behind the PR is enough. -->
The CLI never checked for the token expiry even though it was recorded in the auth file. Now it does.

## Related Jira ticket

<!-- If applicable, share the link to and update the status of the ticket. -->
https://nostosolutions.atlassian.net/browse/SEARCH-2290

## Screenshots

<!-- If there is a visual element to the PR please share screenshots -->
<!-- Remember the saying "one picture says the same as a 1000 words". -->
<img width="866" height="408" alt="image" src="https://github.com/user-attachments/assets/96e5923c-9a95-4f6c-a794-df658279a1bf" />
